### PR TITLE
Fix OSX group error, document local build steps and add a debug mode for verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,20 @@ The cloudenv container stays as minimal as possible while packaging a *lot* of t
 The `latest` tag always points to the most recent image. Where backwards compatibility is an issue (such as with terraform), both the old and new versions will be included.
 
 The 'cloudenv' script pulls the `latest` tag each time it is run. It does not stop or remove running containers however, so you will only use an updated version when you stop/remove the current container. This will happen after a reboot for example.
+
+## Contributing
+
+To build the container locally,
+
+```sh
+docker build -t snw35/cloudenv:latest .
+```
+
+To test the locally built image,
+
+```sh
+./cloudenv
+```
+
+Once your changes are tested, open a pull request with your changes.
+

--- a/README.md
+++ b/README.md
@@ -186,5 +186,12 @@ To test the locally built image,
 ./cloudenv
 ```
 
+To run with DEBUG mode on,
+
+```sh
+export CLOUDENV_DBG=true && ./cloudenv
+```
+
+
 Once your changes are tested, open a pull request with your changes.
 

--- a/cloudenv
+++ b/cloudenv
@@ -4,10 +4,9 @@ set -u
 # Variables
 timezone=Europe/London
 image_name=snw35/cloudenv
-# If you wish to fetch image directly from the repo
-# image_name=https://github.com/snw35/cloudenv.git
 image_tag=latest
 home_directory=$HOME
+debug=false
 
 # Support podman if found on host. Prefer podman as docker=podman alias will likely be active.
 if hash podman 2>/dev/null; then
@@ -59,7 +58,7 @@ if [ ! "$(${container_command} ps -q -f name=$container_name)" ]; then
   ${container_command} rm -f $container_name
 
   # set check to true to debug
-  if false; then
+  if $debug; then
     echo "[DEBUG] -----------------------------------------------------------------"
     echo "[DEBUG] Starting container with command..."
     echo "${container_command} run ${container_command_opts} -dit"

--- a/cloudenv
+++ b/cloudenv
@@ -65,16 +65,17 @@ if [ ! "$(${container_command} ps -q -f name=$container_name)" ]; then
   if $debug; then
     echo "[DEBUG] -----------------------------------------------------------------"
     echo "[DEBUG] Starting container with command..."
-    echo "${container_command} run ${container_command_opts} -dit"
-    echo "    --name $container_name "
-    echo "    --hostname $container_name "
-    echo "    --workdir \"$HOME\" "
-    echo "    --mount type=bind,source=$home_directory,target=\"$HOME\" "
-    echo "    -e TZ=$timezone -e HOST_USER_NAME=\"$(id -u -n)\" "
-    echo "    -e HOST_GROUP_NAME=\"$(id -g -n)\" "
-    echo "    -e HOST_USER_ID=\"$(id -u)\" "
-    echo "    -e HOST_GROUP_ID=\"$(id -g)\" "
-    echo "    -e HOST_HOME_DIRECTORY=\"$HOME\" "
+    echo "${container_command} run ${container_command_opts} -dit \\"
+    echo "    --name $container_name \\"
+    echo "    --hostname $container_name \\"
+    echo "    --workdir \"$HOME\" \\"
+    echo "    --mount type=bind,source=$home_directory,target=\"$HOME\" \\"
+    echo "    -e TZ=$timezone -e HOST_USER_NAME=\"$(id -u -n)\" \\"
+    echo "    -e HOST_GROUP_NAME=\"$(id -g -n)\" \\"
+    echo "    -e HOST_USER_ID=\"$(id -u)\" \\"
+    echo "    -e HOST_GROUP_ID=\"$(id -g)\" \\"
+    echo "    -e HOST_HOME_DIRECTORY=\"$HOME\" \\"
+    echo "    -e DEBUG_MODE=$debug \\"
     echo "    $container_ssh_opts $image_name:$image_tag "
     echo "[DEBUG] -----------------------------------------------------------------"
   fi
@@ -89,6 +90,7 @@ if [ ! "$(${container_command} ps -q -f name=$container_name)" ]; then
     -e HOST_USER_ID="$(id -u)" \
     -e HOST_GROUP_ID="$(id -g)" \
     -e HOST_HOME_DIRECTORY="$HOME" \
+    -e DEBUG_MODE=$debug \
     $container_ssh_opts $image_name:$image_tag &> /dev/null
 
   retVal=$?

--- a/cloudenv
+++ b/cloudenv
@@ -6,7 +6,11 @@ timezone=Europe/London
 image_name=snw35/cloudenv
 image_tag=latest
 home_directory=$HOME
-debug=false
+debug=${CLOUDENV_DBG-false}
+
+if $debug; then
+  echo "[DEBUG] Running with debug mode ON"
+fi
 
 # Support podman if found on host. Prefer podman as docker=podman alias will likely be active.
 if hash podman 2>/dev/null; then

--- a/cloudenv
+++ b/cloudenv
@@ -3,7 +3,9 @@ set -u
 
 # Variables
 timezone=Europe/London
-image_name=https://github.com/smartsheet/cloudenv.git
+image_name=snw35/cloudenv
+# If you wish to fetch image directly from the repo
+# image_name=https://github.com/snw35/cloudenv.git
 image_tag=latest
 home_directory=$HOME
 

--- a/cloudenv
+++ b/cloudenv
@@ -3,7 +3,7 @@ set -u
 
 # Variables
 timezone=Europe/London
-image_name=snw35/cloudenv
+image_name=https://github.com/smartsheet/cloudenv.git
 image_tag=latest
 home_directory=$HOME
 
@@ -55,6 +55,24 @@ ${container_command} pull $image_name:$image_tag
 # If container is not running, remove it so the latest image is used
 if [ ! "$(${container_command} ps -q -f name=$container_name)" ]; then
   ${container_command} rm -f $container_name
+
+  # set check to true to debug
+  if false; then
+    echo "[DEBUG] -----------------------------------------------------------------"
+    echo "[DEBUG] Starting container with command..."
+    echo "${container_command} run ${container_command_opts} -dit"
+    echo "    --name $container_name "
+    echo "    --hostname $container_name "
+    echo "    --workdir \"$HOME\" "
+    echo "    --mount type=bind,source=$home_directory,target=\"$HOME\" "
+    echo "    -e TZ=$timezone -e HOST_USER_NAME=\"$(id -u -n)\" "
+    echo "    -e HOST_GROUP_NAME=\"$(id -g -n)\" "
+    echo "    -e HOST_USER_ID=\"$(id -u)\" "
+    echo "    -e HOST_GROUP_ID=\"$(id -g)\" "
+    echo "    -e HOST_HOME_DIRECTORY=\"$HOME\" "
+    echo "    $container_ssh_opts $image_name:$image_tag "
+    echo "[DEBUG] -----------------------------------------------------------------"
+  fi
 
   ${container_command} run ${container_command_opts} -dit \
     --name $container_name \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+debug=${DEBUG_MODE-false}
+
+[[ $debug = 'true' ]] && echo "[DEBUG] Container running in DEBUG_MODE"
+
 # this if will check if the first argument is a flag
 # but only works if all arguments require a hyphenated flag
 # -v; -SL; -f arg; etc will work, but not arg1 arg2
@@ -65,13 +69,15 @@ if [ "$1" = 'ssh-agent' ]; then
     echo '$HOST_GROUP_ID not set, unable to map external and internal GIDs'
     echo 'Using default GID of 1000 instead'
     HOST_GROUP_ID=1000
+    [[ $debug = 'true' ]] && echo "[DEBUG] groupadd -g $HOST_GROUP_ID $HOST_GROUP_NAME"
     groupadd -g $HOST_GROUP_ID $HOST_GROUP_NAME
   else
     if getent group $HOST_GROUP_ID >/dev/null 2>&1; then
-      HOST_GROUP_NAME=$(id -gn $HOST_GROUP_ID)
+      HOST_GROUP_NAME=$(getent group $HOST_GROUP_ID | cut -d: -f1)
       echo "Matching internal group found, running as $HOST_GROUP_NAME"
     else
       echo "No matching internal group found, creating one..."
+      [[ $debug = 'true' ]] && echo "[DEBUG] groupadd -g $HOST_GROUP_ID $HOST_GROUP_NAME"
       groupadd -g $HOST_GROUP_ID $HOST_GROUP_NAME
     fi
   fi
@@ -81,6 +87,7 @@ if [ "$1" = 'ssh-agent' ]; then
     echo '$HOST_USER_ID not set, unable to map external and internal UIDs'
     echo 'Using default UID of 1000 instead'
     HOST_USER_ID=1000
+    [[ $debug = 'true' ]] && echo "[DEBUG] useradd -l -m -s /bin/bash -u $HOST_USER_ID -g $HOST_GROUP_ID -d $HOST_HOME_DIRECTORY $HOST_USER_NAME"
     useradd -l -m -s /bin/bash -u $HOST_USER_ID -g $HOST_GROUP_ID -d $HOST_HOME_DIRECTORY $HOST_USER_NAME
   else
     # Use an existing internal user if one matches
@@ -89,6 +96,7 @@ if [ "$1" = 'ssh-agent' ]; then
       echo "Matching internal user found, running as $HOST_USER_NAME"
     else
       echo "No matching interneral user found, creating one..."
+      [[ $debug = 'true' ]] && echo "[DEBUG] useradd -l -m -s /bin/bash -u $HOST_USER_ID -g $HOST_GROUP_ID -d $HOST_HOME_DIRECTORY $HOST_USER_NAME"
       useradd -l -m -s /bin/bash -u $HOST_USER_ID -g $HOST_GROUP_ID -d $HOST_HOME_DIRECTORY $HOST_USER_NAME
     fi
   fi


### PR DESCRIPTION
Fix the error we were still getting after @snw35 switched to `getent` for checking if the group exists. The follow on logic for determining the group name was still failing on OSX and this change fixes it.

I've also added a DEBUG mode we can control via the host ENV and some instructions on how to build and test the container locally. The DEBUG logging is off by default and can be enabled with `export CLOUDENV_DBG=true && ./cloudenv`. 

The image below shows what the debug logs look like,

![image](https://user-images.githubusercontent.com/601660/118892987-977c5a80-b8b6-11eb-9adb-a41d7fbaa80c.png)
